### PR TITLE
issue-#86-fix-category-remove

### DIFF
--- a/src/main/java/egl/client/controller/profile/local/LocalProfileSelectController.java
+++ b/src/main/java/egl/client/controller/profile/local/LocalProfileSelectController.java
@@ -29,6 +29,7 @@ class LocalProfileSelectController extends ProfileSelectController {
         localProfilesListView.setService(profileService);
         localProfilesListView.setOnSelect(this::onSelect);
         localProfilesListView.setOnEdit(this::onEdit);
+        localProfilesListView.setOnRemove(this::onRemove);
 
         localProfilesListView.setRowFactory(tv -> new TableRow<>() {
             @Override
@@ -70,6 +71,11 @@ class LocalProfileSelectController extends ProfileSelectController {
             profileService.save(profile);
             localProfilesListView.showItems();
         }
+    }
+
+    private void onRemove(Profile profile) {
+        profileService.remove(profile);
+        localProfilesListView.removeItem(profile);
     }
 
     @Override

--- a/src/main/java/egl/client/controller/topic/LocalTopicsController.java
+++ b/src/main/java/egl/client/controller/topic/LocalTopicsController.java
@@ -124,6 +124,7 @@ public class LocalTopicsController implements Controller {
         categoriesListView.setService(new TypedTopicService(TopicType.CATEGORY));
         categoriesListView.setOnSelect(this::onTopicSelect);
         categoriesListView.setOnEdit(processCategory(this::onCategoryEdit));
+        categoriesListView.setOnRemove(processCategory(this::onCategoryRemove));
 
         createCategoryButton.setOnAction(event -> onCategoryCreate());
         copyCategoryColumn.setOnAction(processCategory(this::onCategoryCopy));
@@ -241,6 +242,15 @@ public class LocalTopicsController implements Controller {
             categoryService.save(category);
             categoriesListView.showItems();
         }
+    }
+
+    private void onCategoryRemove(Category category) {
+        var topic = category.getLocalTopicInfo().getTopic();
+
+        localStatisticService.removeAllBy(topic);
+        categoryService.remove(category);
+
+        categoriesListView.removeItem(topic);
     }
 
     private void onLocalTopicRegister(LocalTopicInfo localTopicInfo) {

--- a/src/main/java/egl/client/repository/core/statistic/TaskStatisticRepository.java
+++ b/src/main/java/egl/client/repository/core/statistic/TaskStatisticRepository.java
@@ -1,5 +1,6 @@
 package egl.client.repository.core.statistic;
 
+import java.util.List;
 import java.util.Optional;
 
 import egl.client.model.core.statistic.TaskStatistic;
@@ -12,4 +13,6 @@ public interface TaskStatisticRepository extends EntityRepository<TaskStatistic>
             TopicStatistic topicStatistic,
             String taskName
     );
+
+    List<TaskStatistic> findAllByTopicStatistic(TopicStatistic topicStatistic);
 }

--- a/src/main/java/egl/client/repository/core/statistic/TopicStatisticRepository.java
+++ b/src/main/java/egl/client/repository/core/statistic/TopicStatisticRepository.java
@@ -1,5 +1,6 @@
 package egl.client.repository.core.statistic;
 
+import java.util.List;
 import java.util.Optional;
 
 import egl.client.model.core.statistic.ProfileStatistic;
@@ -12,4 +13,6 @@ public interface TopicStatisticRepository extends EntityRepository<TopicStatisti
     Optional<TopicStatistic> findByProfileStatisticAndTopic(
             ProfileStatistic profileStatistic, Topic topic
     );
+
+    List<TopicStatistic> findAllByTopic(Topic topic);
 }

--- a/src/main/java/egl/client/service/model/core/TaskStatisticService.java
+++ b/src/main/java/egl/client/service/model/core/TaskStatisticService.java
@@ -1,5 +1,6 @@
 package egl.client.service.model.core;
 
+import java.util.List;
 import java.util.Optional;
 
 import egl.client.model.core.statistic.Result;
@@ -75,5 +76,13 @@ public abstract class TaskStatisticService
     public Optional<TaskStatistic> tryFindBy(TopicStatistic topicStatistic, Task task) {
         var taskStatisticId = toId(topicStatistic, task);
         return tryFindBy(taskStatisticId);
+    }
+
+    public List<TaskStatistic> findAllBy(TopicStatistic topicStatistic) {
+        try {
+            return repository.findAllByTopicStatistic(topicStatistic);
+        } catch (Exception e) {
+            throw new EntityServiceException();
+        }
     }
 }

--- a/src/main/java/egl/client/service/model/core/TopicStatisticService.java
+++ b/src/main/java/egl/client/service/model/core/TopicStatisticService.java
@@ -1,5 +1,6 @@
 package egl.client.service.model.core;
 
+import java.util.List;
 import java.util.Optional;
 
 import egl.client.model.core.statistic.ProfileStatistic;
@@ -62,5 +63,13 @@ public abstract class TopicStatisticService
     public Optional<TopicStatistic> tryFindBy(ProfileStatistic profileStatistic, Topic topic) {
         var topicStatisticId = new TopicStatisticId(profileStatistic, topic);
         return tryFindBy(topicStatisticId);
+    }
+
+    public List<TopicStatistic> findAllBy(Topic topic) {
+        try {
+            return repository.findAllByTopic(topic);
+        } catch (Exception e) {
+            throw new EntityServiceException();
+        }
     }
 }

--- a/src/main/java/egl/client/service/model/local/LocalStatisticService.java
+++ b/src/main/java/egl/client/service/model/local/LocalStatisticService.java
@@ -27,4 +27,14 @@ public class LocalStatisticService
     public Optional<TopicStatistic> findStatisticByLocal(Topic topic) {
         return findBy(topic);
     }
+
+    public void removeAllBy(Topic topic) {
+        topicStatisticService.findAllBy(topic)
+            .forEach(topicStatistic -> {
+                taskStatisticService.findAllBy(topicStatistic)
+                        .forEach(taskStatisticService::remove);
+
+                topicStatisticService.remove(topicStatistic);
+            });
+    }
 }

--- a/src/main/java/egl/client/view/table/list/InfoSelectEditRemoveListView.java
+++ b/src/main/java/egl/client/view/table/list/InfoSelectEditRemoveListView.java
@@ -16,10 +16,4 @@ public class InfoSelectEditRemoveListView<T extends DescribedEntity> extends Inf
     public void showItems() {
         setItems(service.findAll());
     }
-
-    @Override
-    public void removeItem(T entity) {
-        super.removeItem(entity);
-        service.remove(entity);
-    }
 }


### PR DESCRIPTION
Fixed #86: topic and task statistics are removed before, after category removed with cascade